### PR TITLE
feature/20: Create and give style to Entity page

### DIFF
--- a/paradise_papers_django/search/models.py
+++ b/paradise_papers_django/search/models.py
@@ -3,10 +3,6 @@ from neomodel import *
 from neomodel import db
 from django_neomodel import DjangoNode
 
-# config.DATABASE_URL = 'bolt://paradisepapers:paradisepapers@165.227.223.190:7687'
-# Create your models here.
-
-
 #Class for Neo4j databaser nodes
 class Entity(DjangoNode):
     sourceID = StringProperty()
@@ -15,22 +11,29 @@ class Entity(DjangoNode):
     service_provider = StringProperty()
     countries = StringProperty()
     jurisdiction_description =  StringProperty()
-    valid_unti = StringProperty()
+    valid_until = StringProperty()
     ibcRUC = StringProperty()
     name = StringProperty()
     country_codes = StringProperty()
     incorporation_date=StringProperty()
     node_id = StringProperty()
     status = StringProperty()
-    Officers = RelationshipFrom('Officer', 'OFFICER_OF')
-    Intermediaries = RelationshipFrom('Intermediary', 'INTERMEDIARY_OF')
-    Addressess = RelationshipTo('Address', 'REGISTERED_ADDRESS')
-    Others = RelationshipTo('Other' , 'CONNECTED_TO')
+    officers = RelationshipFrom('Officer', 'OFFICER_OF')
+    intermediaries = RelationshipFrom('Intermediary', 'INTERMEDIARY_OF')
+    addressess = RelationshipTo('Address', 'REGISTERED_ADDRESS')
+    others = RelationshipFrom('Other', 'CONNECTED_TO')
+    def Entities_relationship(self):
+        results = self.cypher("START p=node({self}) MATCH n=(p)<-[r]->(x:Entity) RETURN r, x.node_id as Node_id");
+        list =[];
+        for row in results[0]:
+            list.append((row[0].type, Entity.nodes.get(node_id=row[1])))
+        return list
+
 
 class Other(DjangoNode):
     sourceID = StringProperty()
     name = StringProperty()
-    valid_unti = StringProperty()
+    valid_until = StringProperty()
     node_id = StringProperty()
 
 class Intermediary(DjangoNode):
@@ -49,15 +52,15 @@ class Officer(DjangoNode):
     valid_until = StringProperty()
     countries = StringProperty()
     node_id = StringProperty()
-    Addressess = RelationshipTo('Address', 'REGISTERED_ADDRESS')
-    Entities = RelationshipTo('Entity', 'OFFICER_OF')
+    addresses = RelationshipTo('Address', 'REGISTERED_ADDRESS')
+    entities = RelationshipTo('Entity', 'OFFICER_OF')
 
 
 
 class Address(DjangoNode):
     sourceID = StringProperty()
     country_codes = StringProperty()
-    valid_unti = StringProperty()
+    valid_until = StringProperty()
     address = StringProperty()
     countries = StringProperty()
     node_id = StringProperty()
@@ -65,9 +68,8 @@ class Address(DjangoNode):
 # Queries Functions
 def get_all_countries():
     query = "MATCH (n) WHERE NOT n.countries CONTAINS ';' RETURN DISTINCT 'node' as entity, n.countries AS countries UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.countries) RETURN DISTINCT 'relationship' AS entity, r.countries AS countries"
-    results =  db.cypher_query(query)
+    results = db.cypher_query(query)
     return results
-
 
 install_labels(Entity)
 install_labels(Other)

--- a/paradise_papers_django/search/static/css/base.css
+++ b/paradise_papers_django/search/static/css/base.css
@@ -115,12 +115,11 @@ option {
 }
 
 .header-border {
-    height: 95px;
     border-bottom: 2px solid #efefef;
+    height: 95px;
     position: relative;
     z-index: 1;
 }
-
 .entity-container .column-section,
 .entity-container .column-content,
 .intermediary-container .column-section {
@@ -150,8 +149,8 @@ option {
 }
 
 .nav-button {
-    border: none;
     background: none;
+    border: none;
     color: blue;
     text-decoration: underline;
 }
@@ -161,8 +160,8 @@ option {
 }
 
 .active {
-    pointer-events: none;
     cursor: default;
+    pointer-events: none;
     text-decoration: none;
 }
 
@@ -181,4 +180,217 @@ option {
 
 .side-serch {
     width: 30%;
+}
+
+.node header {
+    margin: 2em 0;
+    position: relative;
+}
+.node header h3.node-title {
+    color: #999;
+    font-size: .75em;
+    margin: 0;
+    text-transform: uppercase;
+}
+
+ul.relationships  {
+    font-size: 1.25em;
+    margin: 0 0 1em 0;
+}
+
+ul.relationships  li {
+    margin: 0 0 .5em 0;
+
+}
+
+ul.node-information li  {
+    list-style-type: none;
+    margin: 0 0 .5em 0;
+    padding: 0 2em 0 0;
+}
+ul.node-information li span{
+    display: inline-block;
+}
+
+.node a.node-link {
+    -moz-transition: all 0.15s ease-out 0s;
+    -webkit-transition: all 0.15s ease-out 0s;
+    color: #F8B700;
+    margin: 0 0 .5em 0;
+    outline: none;
+    transition: all 0.15s ease-out 0s;
+}
+
+.left-side{
+    width: 50%;
+}
+.right-side {
+    border-left: 1px solid #efefef;
+    box-sizing: border-box;
+    padding: 0 0 0 2em;
+    width: 50%;
+}
+
+.main-info {
+    -ms-align-content: flex-start;
+    -ms-flex-flow: row wrap;
+    -webkit-align-content: flex-start;
+    -webkit-flex-flow: row wrap;
+    align-content: flex-start;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    font-family: "Lato", "Source Sans Pro", sans-serif, Arial;
+    font-size: .85em;
+    text-rendering: optimizespeed;
+}
+
+.search_content {
+    font-family: "Lato", "Source Sans Pro", sans-serif, Arial;
+}
+.search_results_cont.connections h2 {
+    color: #852308;
+    font-size: 1em;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.search_results_cont.connections h3 {
+    color: #852308;
+    font-size: 1.8em;
+    font-weight: 200;
+    margin: 0.5em 0;
+}
+
+table.display-relationship {
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+}
+
+table.body-table-style th {
+    background: #EDD8CC;
+    padding: 4px 12px;
+}
+
+table.body-table-style th,
+table.body-table-style td {
+    color: #777;
+    font-size: .85em;
+    padding: 9px 12px;
+    text-align: center;
+}
+
+table.body-table-style tr:nth-child(odd) td {
+    background: #F3F3F3;
+}
+
+table.body-table-style td.source,
+table.body-table-style th.source{
+    text-align: right ;
+}
+
+table.body-table-style td.description {
+    text-align: left;
+}
+
+@media only screen and (max-width: 760px),
+(min-device-width: 768px) and (max-device-width: 1024px)  {
+
+    table.body-table-style,
+    table.body-table-stylee thead,
+    table.body-table-style tbody,
+    table.body-table-style th,
+    table.body-table-style td,
+    table.body-table-style tr {
+        display: block;
+    }
+
+    thead tr {
+        left: -9999px;
+        position: absolute;
+        top: -9999px;
+    }
+
+    tr {
+        border: 1px solid #ccc;
+    }
+
+    td {
+        border-bottom: 1px solid #eee;
+        border: none;
+        padding-left: 50%;
+        position: relative;
+    }
+
+    td:before {
+        left: 0px;
+        padding-right: 15px;
+        position: absolute;
+        top: 6px;
+        white-space: nowrap;
+        width: 20%;
+    }
+
+    table.body-table-style td.source a,
+    table.body-table-style th.source a,
+    table.body-table-style td.description a,
+    table.body-table-style td span{
+        margin-left: 70px;
+        margin-right: 0px;
+        right: 0px;
+        text-align: right;
+}
+
+    .entity-table td:nth-of-type(1):before {
+        content: " ";
+    }
+    .entity-table td:nth-of-type(2):before {
+        content: "Role";
+    }
+    .entity-table td:nth-of-type(3):before {
+        content: "Incorporation";
+    }
+    .entity-table td:nth-of-type(4):before {
+        content: "Jurisdiction";
+    }
+    .entity-table td:nth-of-type(5):before {
+        content: "Status";
+    }
+    .entity-table td:nth-of-type(6):before {
+        content: "Data From";
+    }
+
+    .officer-table td:nth-of-type(1):before {
+        content: " ";
+    }
+    .officer-table td:nth-of-type(2):before {
+        content: "Country";
+    }
+    .officer-table td:nth-of-type(3):before {
+        content: "Data From";
+    }
+
+    .intermediary-table td:nth-of-type(1):before {
+        content: " ";
+    }
+    .intermediary-table td:nth-of-type(2):before {
+        content: "Status";
+    }
+    .intermediary-table td:nth-of-type(3):before {
+        content: "Data From";
+    }
+
+    .address-table td:nth-of-type(1):before {
+        content: " ";
+    }
+    .address-table td:nth-of-type(2):before {
+        content: "Data From";
+    }
+
+    .others-table td:nth-of-type(1):before {
+        content: " ";
+    }
+    .others-table td:nth-of-type(2):before {
+        content: "Data From";
+    }
 }

--- a/paradise_papers_django/search/templates/search/display_information/entity.html
+++ b/paradise_papers_django/search/templates/search/display_information/entity.html
@@ -1,60 +1,166 @@
-<h1 class="company-title"> {{ node_info.name }} </h1>
-<h3>  Address: {{ node_info.address }}</h3>
-<p>Incorporated:<strong>{{ node_info.incorporation_date }}</strong></p>
-<p>Registered in: {{ node_info.jurisdiction_description }}</p>
-<p>jurisdiction: {{ node_info.jurisdiction }}</p>
-<p>Service Provider: <strong>{{ node_info.service_provider }}</strong></p>
-<p>Linked countries: {{ node_info.countries }}</p>
-<hr>
-
-{% if others %}
-    <div>
-        <span>Connected to <strong>{{ others|length }} Others</strong></span>
-    </div>
-{% endif  %}
-
-{% if addressess %}
-    <div>
-        <span>Connected to  <strong>{{ addressess|length }} Address</strong></span>
-    </div>
-{% endif  %}
-
-{% if officers %}
-    <div>
-        <span>Connected to  <strong>{{ officers|length }} officers</strong></span>
-    </div>
-{% endif  %}
-
-{% if intermediaries %}
-    <div>
-        <span>Connected to  <strong> {{ intermediaries|length }} intermediaries</strong></span>
-    </div>
-
-    <h4>its Intermediary:</h4>
-    {% for intermediary in intermediaries %}
-        <h3>{{ intermediary.name }}</h3>
-        <p>Status: {{ intermediary.status }}</p>
-        <p>Countries: {{ intermediary.countries }}</p>
-    {% endfor %}
-    <hr>
-{% endif  %}
-
-{% if officers %}
-    <h4> its Officer:</h4>
-    {% for off in officers %}
-        <ul>
-            <li>{{ off.name }}</li>
+{% load nodes_extra %}
+<div class="node">
+   <header>
+      <h3 class="node-title">Entity</h3>
+      <h1 class="company-title">{{ node_info.name }}</h1>
+   </header>
+   <div class="main-info">
+      <div class="left-side">
+         <ul class="relationships">
+            {% if entity_connections %}
             <li>
-                <ul>countries: {{ off.countries }}</ul>
+               <span> Connected to <strong>{{ entity_connections|length }}{% if entity_connections|length > 1 %} Entities {% else %} Entity {% endif %}</strong></span>
+            </li>
+            {% endif %}
+            {% if others %}
+            <li>
+               <span> Connected to <strong>{{ others|length }}{% if others|length > 1 %} Others {% else %} Other {% endif %}</strong></span>
+            </li>
+            {% endif %}
+            {% if addressess %}
+            <li>
+               <span> Connected to <strong>{{ addressess|length }}{% if addressess|length > 1 %} Addresses {% else %} Address {% endif %}</strong></span>
+            </li>
+            {% endif %}
+            {% if officers %}
+            <li>
+               <span>Connected to <strong>{{ officers|length }}{% if officers|length > 1 %} Officers {% else %} officer {% endif %}</strong></span>
+            </li>
+            {% endif %}
+            {% if intermediaries %}
+            <li>
+               <span> Connected to <strong>{{ intermediaries|length }}{% if intermediaries|length > 1 %} Intermediaries {% else %} Intermediary {% endif %}</strong></span>
+            </li>
+            {% endif %}
+         </ul>
+         <ul class="node-information">
+            <li>
+               <span>Incorporated:</span> <strong>{{ node_info.incorporation_date }}</strong>
             </li>
             <li>
-                <ul>source: {{ off.sourceID }}</ul>
+               <span>Status:</span> <strong>{{ node_info.status }}</strong>
             </li>
-        </ul>
-    {% endfor%}
-{% endif  %}
+            <li>
+               <span>Registered in:</span> <a class="node-link" href="#">{{ node_info.jurisdiction_description }}</a>
+            </li>
+            <li>
+               <span>Linked countries:</span> <a class="node-link" href="#">{{ node_info.countries }}</a>
+            </li>
+         </ul>
+      </div>
+      <div class="right-side">
+         <ul>
+            <li>
+               <span>Data from:</span> <a class="node-link" href="#">{{ node_info.sourceID }}</a>
+            </li>
+            <li>
+               <span>Agent:</span> <strong>{{ node_info.service_provider }}</strong>
+            </li>
+            <li>
+               <span>{{ node_info.valid_until }} </span>
+            </li>
+         </ul>
+      </div>
+   </div>
+   <div class="search_results_cont connections">
+      <h2>Connections</h2>
+      {% if entity_connections %}
 
-{% if addressess %}
-    <h4>Address connected:</h4>
-    {{ addressess }}
-{% endif  %}
+      <h3>Entity</h3>
+      <table class="display-relationship body-table-style entity-table">
+         <tbody>
+            <thead>
+               <th></th>
+               <th class="Role">Role</th>
+               <th class="Incorporation">Incorporation</th>
+               <th class="Jurisdiction">Jurisdiction</th>
+               <th class="Status">Status</th>
+               <th class="source">Data From</th>
+            </thead>
+            {% for entity in entity_connections %}
+            <tr>
+                <td class="description"><a class="node-link" title="{{ entity.1.name }}" href="/search/{{ entity.1.node_id }}">{{ entity.1.name }}</a></td>
+                <td class="Role">{{ entity.0 | changeUnderline  }}</td>
+                <td class="Incorporation"><span>{{entity.1.incorporation_date}}</span></td>
+                <td class="Jurisdiction"><span>{{entity.1.jurisdiction}}</span></td>
+                <td class="status"><span>{{entity.1.status}}</span></td>
+                <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{entity.1.sourceID}}</a></td>
+            </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+      {% endif %}
+      {% if officers %}
+      <h3>Officer</h3>
+      <table class="display-relationship body-table-style officer-table">
+         <tbody>
+            <thead>
+               <th></th>
+               <th class="country">Country</th>
+               <th class="source">Data From</th>
+            </thead>
+            {% for off in officers %}
+            <tr>
+               <td class="description"><a class="node-link" title="{{ off.name }}" href="/search/{{ off.node_id }}">{{ off.name }}</a></td>
+               <td class="country"><span>{{off.countries}}</span></td>
+               <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{off.sourceID}}</a></td>
+            </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+      {% endif %}
+      {% if intermediaries %}
+      <h3>Intermediary</h3>
+      <table class="display-relationship body-table-style intermediary-table">
+         <tbody>
+            <thead>
+               <th></th>
+               <th class="Status">Status</th>
+               <th class="source">Data From</th>
+            </thead>
+            {% for intermediary in intermediaries %}
+            <tr>
+               <td class="description"><a class="node-link" title="{{ intermediary.name }}" href="/search/{{ intermediary.node_id }}">{{ intermediary.name }}N</a></td>
+               <td class="status"><span>{{intermediary.status}}</span></td>
+               <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{intermediary.sourceID}}</a></td>
+            </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+      {% endif %}
+      {% if addressess %}
+      <h3>Address</h3>
+      <table class="display-relationship body-table-style address-table">
+         <tbody>
+            <thead>
+               <th></th>
+               <th class="source">Data From</th>
+            </thead>
+            {% for add in addressess %}
+            <tr>
+               <td class="description"><a class="node-link" href="/search/{{ add.node_id }}">{{ add.address }}</a></td>
+               <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{add.sourceID}}</a></td>
+            </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+      {% endif %}
+      {% if others %}
+      <h3>Other</h3>
+      <table class="display-relationship body-table-style others-table">
+         <tbody>
+            <thead>
+               <th></th>
+               <th class="source">Data From</th>
+            </thead>
+            {% for other in others %}
+            <tr>
+               <td class="description"><a class="node-link" title="{{ off.name }}" href="/search/{{ other.node_id }}">{{ other.name }}</a></td>
+               <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{other.sourceID}}</a></td>
+            </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+      {% endif %}
+   </div>
+</div>

--- a/paradise_papers_django/search/templates/search/display_information/officer.html
+++ b/paradise_papers_django/search/templates/search/display_information/officer.html
@@ -2,14 +2,14 @@
 <p>Linked countries: {{ node_info.countries }}</p>
 <p>Data From: {{node_info.sourceID}}</p>
 
-{% if addressess %}
+{% if addresses %}
     <div>
-        <span>  Connected to  <strong> {{ addressess|length }} Address</strong></span>
+        <span>Connected to<strong> {{ addresses|length }} Address</strong></span>
     </div>
 {% endif  %}
 
 {% if entities %}
     <div>
-        <span> Connected to  <strong> {{ entities|length }} entities</strong></span>
+        <span>Connected to<strong> {{ entities|length }} entities</strong></span>
     </div>
 {% endif  %}

--- a/paradise_papers_django/search/templates/search/nodeSearch.html
+++ b/paradise_papers_django/search/templates/search/nodeSearch.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     {% include "search/searchbar.html" %}
-        {% with template_name=nodeType|stringformat:"s"|add:".html" %}
+        {% with template_name=node_type|stringformat:"s"|add:".html" %}
             {% include "search/display_information/"|add:template_name %}
         {% endwith %}
 {% endblock %}

--- a/paradise_papers_django/search/templates/search/nodes_templates/entity.html
+++ b/paradise_papers_django/search/templates/search/nodes_templates/entity.html
@@ -10,7 +10,7 @@
     {% for entity in entities %}
         <div class="column-content">
             <div class="node-title">
-                <a href="/search/{{ entity.node_id }}?cou">{{entity.name}}</a>
+                <a href="/search/{{ entity.node_id }}">{{entity.name}}</a>
             </div>
 
             <div class="node-field">

--- a/paradise_papers_django/search/templatetags/nodes_extra.py
+++ b/paradise_papers_django/search/templatetags/nodes_extra.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def changeUnderline(string):
+    return string.replace('_', ' ')

--- a/paradise_papers_django/search/views.py
+++ b/paradise_papers_django/search/views.py
@@ -52,29 +52,31 @@ class ResultPage(TemplateView):
 def nodes(request, node_id):
     try:
         node_info = Entity.nodes.get(node_id=node_id)
-        intermediaries = node_info.Intermediaries.all()
-        officers = node_info.Officers.all()
-        addressess = node_info.Addressess.all()
-        others = node_info.Others.all()
+        intermediaries = node_info.intermediaries.all()
+        officers = node_info.officers.all()
+        addresses = node_info.addressess.all()
+        others = node_info.others.all()
+        entity = node_info.Entities_relationship();
         context = {
             'node_info': node_info,
             'intermediaries': intermediaries,
-            'officers' : officers,
-            'addressess' : addressess,
-            'nodeType' : 'entity',
-            'others' : 'others',
+            'officers': officers,
+            'addresses': addresses,
+            'node_type': 'entity',
+            'others': others,
+            'entity_connections': entity,
         }
     except Entity.DoesNotExist:
             pass
     try:
         node_info = Officer.nodes.get(node_id=node_id)
-        entities = node_info.Entities.all()
-        addressess = node_info.Addressess.all()
+        entities = node_info.entities.all()
+        addresses = node_info.addresses.all()
         context = {
             'node_info': node_info,
-            'entities' :entities,
-            'addressess': addressess,
-            'nodeType': 'officer',
+            'entities': entities,
+            'addresses': addresses,
+            'node_type': 'officer',
         }
     except Officer.DoesNotExist:
             pass
@@ -83,7 +85,7 @@ def nodes(request, node_id):
         node_info = Intermediary.nodes.get(node_id=node_id)
         context = {
             'node_info': node_info,
-            'nodeType': 'intermediary',
+            'node_type': 'intermediary',
         }
     except Intermediary.DoesNotExist:
         pass


### PR DESCRIPTION
Closes [20](https://trello.com/c/qugc2wql/20-as-a-user-i-want-entity-profiles-to-have-entity-node-to-be-broken-down-into-a-table-so-that-i-can-connections-summary)

<!-- What issue is solve by pull request solve? -->
This feature is to display the corresponding information when an entity node is searched 
<!-- Additional notes -->


## Testing

Steps to manually verify the change:
1. _Setup_: download PR and change the neo4j db config to local . 
2. _Exercise_: Run The server and go to: **http://127.0.0.1:8000/** , search for  **http://127.0.0.1:8000/search/82020331** or any  node 
3. _Verify_: see if the information matches or is similar to the one on the leaks website ex with node 82020331

![image](https://user-images.githubusercontent.com/29434543/34420952-d600d956-ebe2-11e7-9eeb-623f04e41891.png)
![image](https://user-images.githubusercontent.com/29434543/34420979-00dc5c22-ebe3-11e7-9a05-19bfa4f2251b.png)

