### PR TITLE
feature/21: Create, and give style to Officer page

### DIFF
--- a/paradise_papers_django/paradise_papers_django/settings.py
+++ b/paradise_papers_django/paradise_papers_django/settings.py
@@ -124,10 +124,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, "static"),
-)
-#
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'

--- a/paradise_papers_django/search/models.py
+++ b/paradise_papers_django/search/models.py
@@ -20,7 +20,7 @@ class Entity(DjangoNode):
     status = StringProperty()
     officers = RelationshipFrom('Officer', 'OFFICER_OF')
     intermediaries = RelationshipFrom('Intermediary', 'INTERMEDIARY_OF')
-    addressess = RelationshipTo('Address', 'REGISTERED_ADDRESS')
+    addresses = RelationshipTo('Address', 'REGISTERED_ADDRESS')
     others = RelationshipFrom('Other', 'CONNECTED_TO')
     def Entities_relationship(self):
         results = self.cypher("START p=node({self}) MATCH n=(p)<-[r]->(x:Entity) RETURN r, x.node_id as Node_id");
@@ -54,6 +54,15 @@ class Officer(DjangoNode):
     node_id = StringProperty()
     addresses = RelationshipTo('Address', 'REGISTERED_ADDRESS')
     entities = RelationshipTo('Entity', 'OFFICER_OF')
+    intermediaries = RelationshipTo('Intermediary', 'OFFICER_OF')
+    others = RelationshipTo('Other', 'OFFICER_OF')
+
+    def officers_relationship(self):
+        results = self.cypher("START p=node({self}) MATCH n=(p)<-[r]->(x:Officer) RETURN r, x.node_id as Node_id");
+        list =[];
+        for row in results[0]:
+            list.append((row[0].type, Officer.nodes.get(node_id=row[1])))
+        return list
 
 
 

--- a/paradise_papers_django/search/templates/search/display_information/entity.html
+++ b/paradise_papers_django/search/templates/search/display_information/entity.html
@@ -24,7 +24,7 @@
             {% endif %}
             {% if officers %}
             <li>
-               <span>Connected to <strong>{{ officers|length }}{% if officers|length > 1 %} Officers {% else %} officer {% endif %}</strong></span>
+               <span>Connected to <strong>{{ officers|length }}{% if officers|length > 1 %} Officers {% else %} Officer {% endif %}</strong></span>
             </li>
             {% endif %}
             {% if intermediaries %}
@@ -44,12 +44,12 @@
                <span>Registered in:</span> <a class="node-link" href="#">{{ node_info.jurisdiction_description }}</a>
             </li>
             <li>
-               <span>Linked countries:</span> <a class="node-link" href="#">{{ node_info.countries }}</a>
+               <span>Linked countries:</span> <a class="node-link" href="#">{{ node_info.countries|changeSemicolumn }}</a>
             </li>
          </ul>
       </div>
       <div class="right-side">
-         <ul>
+         <ul class="node-information">
             <li>
                <span>Data from:</span> <a class="node-link" href="#">{{ node_info.sourceID }}</a>
             </li>
@@ -102,7 +102,7 @@
             {% for off in officers %}
             <tr>
                <td class="description"><a class="node-link" title="{{ off.name }}" href="/search/{{ off.node_id }}">{{ off.name }}</a></td>
-               <td class="country"><span>{{off.countries}}</span></td>
+               <td class="country"><span>{{off.countries|changeSemicolumn}}</span></td>
                <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{off.sourceID}}</a></td>
             </tr>
             {% endfor %}

--- a/paradise_papers_django/search/templates/search/display_information/intermediary.html
+++ b/paradise_papers_django/search/templates/search/display_information/intermediary.html
@@ -1,3 +1,5 @@
+
+
 <h1 class="company-title"> {{ node_info.name }} </h1>
 <p>Linked countries: {{ node_info.countries }}</p>
 <p>Status: {{ node_info.status }}</p>

--- a/paradise_papers_django/search/templates/search/display_information/officer.html
+++ b/paradise_papers_django/search/templates/search/display_information/officer.html
@@ -1,15 +1,155 @@
-<h1 class="company-title"> {{ node_info.name }} </h1>
-<p>Linked countries: {{ node_info.countries }}</p>
-<p>Data From: {{node_info.sourceID}}</p>
+{% load nodes_extra %}
+<div class="node">
+  <header>
+      <h3 class="node-title">OFFICER</h3>
+      <h1 class="company-title">{{ node_info.name }}</h1>
+   </header>
+    <div class="main-info">
+       <div class="left-side">
+          <ul class="relationships">
+            {% if entities %}
+              <li>
+                <span>Connected to <strong>{{ entities|length }}{% if entities|length > 1 %} Entities {% else %} Entity {% endif %}</strong></span>
+              </li>
+            {% endif  %}
+            {% if officer_connections %}
+               <li>
+                  <span> Connected to <strong>{{ officer_connections|length }}{% if officer_connections|length > 1 %} Officers {% else %} Officer {% endif %}</strong></span>
+               </li>
+            {% endif %}
+             {% if others %}
+                <li>
+                   <span> Connected to <strong>{{ others|length }}{% if others|length > 1 %} Others {% else %} Other {% endif %}</strong></span>
+                </li>
+            {% endif %}
+            {% if addresses %}
+               <li>
+                   <span>Connected to <strong>{{ addresses|length }}{% if addresses|length > 1 %} Addresses {% else %} Address {% endif %}</strong></span>
+               </li>
+            {% endif  %}
+            {% if intermediaries %}
+            <li>
+               <span> Connected to <strong>{{ intermediaries|length }}{% if intermediaries|length > 1 %} Intermediaries {% else %} Intermediary {% endif %}</strong></span>
+            </li>
+            {% endif %}
 
-{% if addresses %}
-    <div>
-        <span>Connected to<strong> {{ addresses|length }} Address</strong></span>
-    </div>
-{% endif  %}
+          </ul>
+           <ul class="node-information">
+            <li>
+               <span>Linked countries:</span>
+                {% with node_info.countries|split:";" as countries %}
+                    {% for skill in countries %}
+                        <a class="node-link" href="#">{{ skill }}</a>, 
+                    {% endfor %}
+                {% endwith %}
+            </li>
+            <li>
+               <span>Data from:</span> <a class="node-link" href="#">{{ node_info.sourceID }}</a>
+            </li>
+            <li>
+               <strong><span>{{ node_info.valid_until }}</span></strong>
+            </li>
+         </ul>
 
-{% if entities %}
-    <div>
-        <span>Connected to<strong> {{ entities|length }} entities</strong></span>
+       </div>
     </div>
-{% endif  %}
+    <div class="search_results_cont connections">
+      <h2>Connections</h2>
+      {% if entities %}
+          <h3>Entity</h3>
+          <table class="display-relationship body-table-style entity-table">
+             <tbody>
+                <thead>
+                   <th></th>
+                   <th class="Incorporation">Incorporation</th>
+                   <th class="Jurisdiction">Jurisdiction</th>
+                   <th class="Status">Status</th>
+                   <th class="source">Data From</th>
+                </thead>
+                {% for entity in entities %}
+                <tr>
+                    <td class="description"><a class="node-link" title="{{ entity.name }}" href="/search/{{ entity.node_id }}">{{ entity.name }}</a></td>
+                    <td class="Incorporation"><span>{{entity.incorporation_date}}</span></td>
+                    <td class="Jurisdiction"><span>{{entity.jurisdiction}}</span></td>
+                    <td class="status"><span>{{entity.status}}</span></td>
+                    <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{entity.sourceID}}</a></td>
+                </tr>
+                {% endfor %}
+             </tbody>
+      </table>
+      {% endif %}
+      {% if officer_connections %}
+          <h3>Officer</h3>
+          <table class="display-relationship body-table-style officer-table">
+             <tbody>
+                <thead>
+                   <th></th>
+                   <th class="country">Country</th>
+                   <th class="source">Data From</th>
+                </thead>
+                {% for off in officer_connections %}
+                <tr>
+                   <td class="description"><a class="node-link" title="{{ off.1.name }}" href="/search/{{ off.1.node_id }}">{{ off.1.name }}</a></td>
+                   <td class="country"><span>{{off.1.countries | changeSemicolumn}}</span></td>
+                   <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{off.1.sourceID}}</a></td>
+                </tr>
+                {% endfor %}
+              </tbody>
+          </table>
+      {% endif %}
+      {% if intermediaries %}
+          <h3>Intermediary</h3>
+          <table class="display-relationship body-table-style intermediary-table">
+             <tbody>
+                <thead>
+                   <th></th>
+                   <th class="Status">Status</th>
+                   <th class="source">Data From</th>
+                </thead>
+                {% for intermediary in intermediaries %}
+                <tr>
+                   <td class="description"><a class="node-link" title="{{ intermediary.name }}" href="/search/{{ intermediary.node_id }}">{{ intermediary.name }}N</a></td>
+                   <td class="status"><span>{{intermediary.status}}</span></td>
+                   <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{intermediary.sourceID}}</a></td>
+                </tr>
+                {% endfor %}
+             </tbody>
+          </table>
+      {% endif %}
+      {% if addresses %}
+          <h3>Address</h3>
+          <table class="display-relationship body-table-style address-table">
+             <tbody>
+                <thead>
+                   <th></th>
+                   <th class="source">Data From</th>
+                </thead>
+                {% for add in addresses %}
+                <tr>
+                   <td class="description"><a class="node-link" href="/search/{{ add.node_id }}">{{ add.address }}</a></td>
+                   <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{add.sourceID}}</a></td>
+                </tr>
+                {% endfor %}
+             </tbody>
+          </table>
+      {% endif %}
+      {% if others %}
+          <h3>Other</h3>
+          <table class="display-relationship body-table-style others-table">
+             <tbody>
+                <thead>
+                   <th></th>
+                   <th class="source">Data From</th>
+                </thead>
+                {% for other in others %}
+                <tr>
+                   <td class="description"><a class="node-link" title="{{ off.name }}" href="/search/{{ other.node_id }}">{{ other.name }}</a></td>
+                   <td class="source"><a class="node-link" href="https://panamapapers.icij.org">{{other.sourceID}}</a></td>
+                </tr>
+                {% endfor %}
+             </tbody>
+          </table>
+      {% endif %}
+   </div>
+
+</div>

--- a/paradise_papers_django/search/templatetags/nodes_extra.py
+++ b/paradise_papers_django/search/templatetags/nodes_extra.py
@@ -6,3 +6,13 @@ register = template.Library()
 @register.filter
 def changeUnderline(string):
     return string.replace('_', ' ')
+
+
+@register.filter
+def changeSemicolumn(string):
+    return string.replace(';', ', ')
+
+
+@register.filter(name='split')
+def split(value, key):
+    return value.split(key)

--- a/paradise_papers_django/search/views.py
+++ b/paradise_papers_django/search/views.py
@@ -54,7 +54,7 @@ def nodes(request, node_id):
         node_info = Entity.nodes.get(node_id=node_id)
         intermediaries = node_info.intermediaries.all()
         officers = node_info.officers.all()
-        addresses = node_info.addressess.all()
+        addresses = node_info.addresses.all()
         others = node_info.others.all()
         entity = node_info.Entities_relationship();
         context = {
@@ -70,13 +70,19 @@ def nodes(request, node_id):
             pass
     try:
         node_info = Officer.nodes.get(node_id=node_id)
+        intermediaries = node_info.intermediaries.all()
         entities = node_info.entities.all()
+        others = node_info.others.all()
+        officers = node_info.officers_relationship();
         addresses = node_info.addresses.all()
         context = {
             'node_info': node_info,
             'entities': entities,
             'addresses': addresses,
             'node_type': 'officer',
+            'officer_connections': officers,
+            'others': others,
+            'intermediaries': intermediaries,
         }
     except Officer.DoesNotExist:
             pass


### PR DESCRIPTION
Closes [21](https://trello.com/c/Xm9Kemvx/21-as-a-user-i-want-entity-profiles-to-have-officer-node-to-be-break-down-into-a-table-so-that-i-can-see-connection-summary)

<!-- What issue is solve by pull request solve? -->

<!-- Additional notes -->


## Testing

Steps to manually verify the change:
1. _Setup_:Step to set the environment
2. _Exercise_: Search any node that is officer. Ex: http://127.0.0.1:8000/search/91197
3. _Verify_: what we need to verify that the information on the page is the same/similar that the same node in the offshoreleaks website. Ex: https://offshoreleaks.icij.org/nodes/91197
