### PR TITLE
change DjangoNode to StructuredNode

### DIFF
--- a/paradise_papers_search/fetch_api/models/Address.py
+++ b/paradise_papers_search/fetch_api/models/Address.py
@@ -1,9 +1,7 @@
 from neomodel import *
-from neomodel import db
-from django_neomodel import DjangoNode
 from . import helpers
 
-class Address(DjangoNode):
+class Address(StructuredNode):
     sourceID      = StringProperty()
     country_codes = StringProperty()
     valid_until   = StringProperty()

--- a/paradise_papers_search/fetch_api/models/Entity.py
+++ b/paradise_papers_search/fetch_api/models/Entity.py
@@ -1,11 +1,9 @@
 from neomodel import *
-from neomodel import db
-from django_neomodel import DjangoNode
 from . import helpers
 
 
 #Class for Neo4j databaser nodes
-class Entity(DjangoNode):
+class Entity(StructuredNode):
     sourceID                 = StringProperty()
     address                  = StringProperty()
     jurisdiction             = StringProperty()

--- a/paradise_papers_search/fetch_api/models/Intermediary.py
+++ b/paradise_papers_search/fetch_api/models/Intermediary.py
@@ -1,9 +1,7 @@
 from neomodel import *
-from neomodel import db
-from django_neomodel import DjangoNode
 from . import helpers
 
-class Intermediary(DjangoNode):
+class Intermediary(StructuredNode):
     sourceID      = StringProperty()
     valid_until   = StringProperty()
     name          = StringProperty()

--- a/paradise_papers_search/fetch_api/models/Officer.py
+++ b/paradise_papers_search/fetch_api/models/Officer.py
@@ -1,10 +1,7 @@
 from neomodel import *
-from neomodel import db
-from django_neomodel import DjangoNode
-from django_neomodel import DjangoNode
 from . import helpers
 
-class Officer(DjangoNode):
+class Officer(StructuredNode):
     sourceID      = StringProperty()
     name          = StringProperty()
     country_codes = StringProperty()

--- a/paradise_papers_search/fetch_api/models/Other.py
+++ b/paradise_papers_search/fetch_api/models/Other.py
@@ -1,9 +1,7 @@
 from neomodel import *
-from neomodel import db
-from django_neomodel import DjangoNode
 from . import helpers
 
-class Other(DjangoNode):
+class Other(StructuredNode):
     sourceID    = StringProperty()
     name        = StringProperty()
     valid_until = StringProperty()


### PR DESCRIPTION
Closes [Ticket](https://trello.com)

<!-- What issue is solve by pull request solve? -->
`DjangoNode`  is for forms, since we are not using forms on our app it is better to change it to `StructuredNode`
<!-- Additional notes -->


## Testing

Steps to manually verify the change:
3. _Verify_: Anything broke when changing the nodes 
