### PR TITLE
Update neomodel and make it heroku deployable

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd paradise_papers_search && gunicorn paradise_papers_search.wsgi

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ A simple Django web app for searching the Paradise Papers dataset backed by Neo4
 # Requirements
 
 - Python 3.4+
-- Django 1.11
+- Django 2.2
 - neo4j 3.0, 3.1, 3.2, 3.3
 - neo4j-driver 1.2.1
-- neomodel 3.2.5
+- neomodel 4.0.2
 
 
 # Quickstart
@@ -23,7 +23,7 @@ git clone https://github.com/neo4j-examples/paradise-papers-django
 cd paradise-papers-django
 cd paradise_papers_search
 
-# Run the app(after installing requirements)
+# Run the app (after installing requirements)
 python manage.py runserver --settings=paradise_papers_search.settings.dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,20 @@ A simple Django web app for searching the Paradise Papers dataset backed by Neo4
 - neo4j-driver 1.2.1
 - neomodel 4.0.2
 
-
 # Quickstart
+
+First create an [sandbox database](https://sandbox.neo4j.com/), make sure to select **Paradise Papers by ICIJ** under **Pre-Built Data**, copy the credentials: username, password and bolt URL, you are going to need that later.
 
 ``` bash
 # Clone this repository
 git clone https://github.com/neo4j-examples/paradise-papers-django
 
 # Go into the repository
-cd paradise-papers-django
-cd paradise_papers_search
+cd paradise-papers-django/paradise_papers_search
+pip install -r ../requirements.txt
 
-# Run the app (after installing requirements)
+# Run the app
+export DATABASE_URL=bolt://user:password@hostnameOrIP:port # update with the credentials from your sandbox database.
 python manage.py runserver --settings=paradise_papers_search.settings.dev
 ```
 

--- a/paradise_papers_search/fetch_api/admin.py
+++ b/paradise_papers_search/fetch_api/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/paradise_papers_search/paradise_papers_search/requirements.txt
+++ b/paradise_papers_search/paradise_papers_search/requirements.txt
@@ -1,7 +1,0 @@
-Django==1.11.2
-django-neomodel==0.0.4
-djangorestframework==3.7.7
-neo4j-driver==1.2.1
-neomodel==3.2.5
-pytz==2017.3
-whitenoise==3.3.1

--- a/paradise_papers_search/paradise_papers_search/settings/base.py
+++ b/paradise_papers_search/paradise_papers_search/settings/base.py
@@ -12,6 +12,11 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import os
 from neomodel import config
+from .env import env
+
+#Connect to Neo4j Database
+config.DATABASE_URL = env('DATABASE_URL')  # default
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -25,6 +30,8 @@ SECRET_KEY = '7jvc876=)%+t5^k4p0qd^ysi@4317lo*r+ki^r3)e(*g-efh&^'
 
 INSTALLED_APPS = [
     'django_neomodel',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',

--- a/paradise_papers_search/paradise_papers_search/settings/base.py
+++ b/paradise_papers_search/paradise_papers_search/settings/base.py
@@ -15,7 +15,6 @@ from neomodel import config
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
@@ -26,9 +25,6 @@ SECRET_KEY = '7jvc876=)%+t5^k4p0qd^ysi@4317lo*r+ki^r3)e(*g-efh&^'
 
 INSTALLED_APPS = [
     'django_neomodel',
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -40,7 +36,6 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/paradise_papers_search/paradise_papers_search/settings/dev.py
+++ b/paradise_papers_search/paradise_papers_search/settings/dev.py
@@ -2,6 +2,3 @@ from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-
-#Connect to Neo4j Database
-config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687'

--- a/paradise_papers_search/paradise_papers_search/settings/env.py
+++ b/paradise_papers_search/paradise_papers_search/settings/env.py
@@ -1,0 +1,22 @@
+import ast
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+def env(key, default=None, required=True):
+    """
+    Retrieves environment variables and returns Python natives. The (optional)
+    default will be returned if the environment variable does not exist.
+    """
+    try:
+        value = os.environ[key]
+        return ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        value = value.replace("**newline**", "\n")
+        return value
+    except KeyError:
+        if default or not required:
+            return default
+        raise ImproperlyConfigured("Missing required environment variable '%s'" % key)
+

--- a/paradise_papers_search/paradise_papers_search/settings/production.py
+++ b/paradise_papers_search/paradise_papers_search/settings/production.py
@@ -4,10 +4,6 @@ from .env import env
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-#Connect to Neo4j Database
-config.DATABASE_URL = env('DATABASE_URL')  # default
-
-
 MIDDLEWARE += ['whitenoise.middleware.WhiteNoiseMiddleware', ]
 
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'

--- a/paradise_papers_search/paradise_papers_search/settings/production.py
+++ b/paradise_papers_search/paradise_papers_search/settings/production.py
@@ -1,14 +1,15 @@
 from .base import *
+from .env import env
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
 #Connect to Neo4j Database
-config.DATABASE_URL = 'bolt://paradisepapers:paradisepapers@174.138.63.95:7687'  # default
+config.DATABASE_URL = env('DATABASE_URL')  # default
 
 
 MIDDLEWARE += ['whitenoise.middleware.WhiteNoiseMiddleware', ]
 
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
-ALLOWED_HOSTS = ['paradise-papers-django.herokuapp.com', '10.0.0.72']
+ALLOWED_HOSTS = [env('ALLOWED_HOST')]

--- a/paradise_papers_search/paradise_papers_search/urls.py
+++ b/paradise_papers_search/paradise_papers_search/urls.py
@@ -20,5 +20,5 @@ from django.views.generic import TemplateView
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^$', TemplateView.as_view(template_name='index.html'), name='index'),
-    url(r'^fetch/', include('fetch_api.urls', namespace='fetch_api')),
+    url(r'^fetch/', include('fetch_api.urls')),
 ]

--- a/paradise_papers_search/paradise_papers_search/urls.py
+++ b/paradise_papers_search/paradise_papers_search/urls.py
@@ -14,11 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf.urls import url, include
-from django.contrib import admin
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
     url(r'^$', TemplateView.as_view(template_name='index.html'), name='index'),
     url(r'^fetch/', include('fetch_api.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Django==2.2
+gunicorn==20.0.4
+django-neomodel==0.0.6
+djangorestframework==3.7.7
+neo4j-driver==4.1.1
+neomodel==4.0.2
+pytz==2020.5
+whitenoise==3.3.1


### PR DESCRIPTION
Updates django and neomodel and also added a `Procfile` to make it easier to deploy to heroku.

How to test:

1. Create an [sandbox database](https://sandbox.neo4j.com/), make sure to select **Paradise Papers by ICIJ** under **Pre-Built Data**, copy the credentials: username, password and bolt URL, you are going to need that later.
2. Create an heroku app, lets call it `paradise-papers` as an example.
    1. Go to its settings and add the following config vars:
        1. `ALLOWED_HOST` with your heroku app URL, in this example: `paradise-papers.herokuapp.com`
        2. `DATABASE_URL` with the credentials from your sandbox database in the following format: `bolt://user:password@ip:port`
3. Clone the repository `git clone git@github.com:silverlogic/paradise-papers-django.git`
4. `cd paradise-papers-django`
5. Change to this branch `git checkout GGP-409-heroku`
6. Add your heroku app's git URL as a remote `git remote add heroku https://git.heroku.com/paradise-papers.git`
7. Push to heroku to deploy the app `git push heroku master`
8. Go to your app URL http://paradise-papers.herokuapp.com
